### PR TITLE
Bringing lib in line with Blizzard changes

### DIFF
--- a/include/blizz_api_endpoint_builder.hpp
+++ b/include/blizz_api_endpoint_builder.hpp
@@ -28,7 +28,7 @@ class BaseEndpointBuilder : public BaseBuilder<T>
         : mCommunityArea(BLIZZARD_WOW_COMM::BWC_EU)
         , mLocale(BLIZZARD_LOCALE::BL_EN_GB)
         , mJsonp("")
-        , mApiKey("abcdefghijklmnopqrstuvwxyz")
+        , mAccessToken("abcdefghijklmnopqrstuvwxyz")
     {
     }
 
@@ -50,9 +50,9 @@ class BaseEndpointBuilder : public BaseBuilder<T>
         return static_cast<T&>(*this);
     }
 
-    T& WithApiKey(const std::string& ApiKey)
+    T& WithAccessToken(const std::string& AccessToken)
     {
-        mApiKey = ApiKey;
+        mAccessToken = AccessToken;
         return static_cast<T&>(*this);
     }
 
@@ -75,8 +75,8 @@ class BaseEndpointBuilder : public BaseBuilder<T>
             endpointOss << mJsonp;
         }
 
-        endpointOss << "&apikey=";
-        endpointOss << mApiKey;
+        endpointOss << "&access_token=";
+        endpointOss << mAccessToken;
 
         return endpointOss.str();
     }
@@ -91,7 +91,7 @@ class BaseEndpointBuilder : public BaseBuilder<T>
     BLIZZARD_WOW_COMM mCommunityArea;
     BLIZZARD_LOCALE mLocale;
     std::string mJsonp;
-    std::string mApiKey;
+    std::string mAccessToken;
 };
 
 class ItemEndpointBuilder

--- a/sources/utest/itemEndpointBuilderTest_gtest.cpp
+++ b/sources/utest/itemEndpointBuilderTest_gtest.cpp
@@ -13,7 +13,7 @@ TEST(ItemEndpointBuilderTest, DefaultParamsTest)
 {
     std::string actual = BlizzItemEndpointBuilder::GetBuilder().BuildString();
     std::string expected =
-        "https://eu.api.battle.net/wow/item/12345?locale=en_GB&apikey=abcdefghijklmnopqrstuvwxyz";
+        "https://eu.api.battle.net/wow/item/12345?locale=en_GB&access_token=abcdefghijklmnopqrstuvwxyz";
     EXPECT_EQ(expected, actual);
 }
 
@@ -27,7 +27,7 @@ TEST(ItemEndpointBuilderTest, UsCommDeLocaleRndVal)
                              .BuildString();
 
     std::string expected =
-        "https://us.api.battle.net/wow/item/72344?locale=de_DE&jsonp=rndVal&apikey=abcdefghijklmnopqrstuvwxyz";
+        "https://us.api.battle.net/wow/item/72344?locale=de_DE&jsonp=rndVal&access_token=abcdefghijklmnopqrstuvwxyz";
     EXPECT_EQ(expected, actual);
 }
 
@@ -35,17 +35,17 @@ TEST(ItemEndpointBuilderTest, DefaultWithApiKey)
 {
     std::string actual = BlizzItemEndpointBuilder::GetBuilder()
                              .WithItemId(14423)
-                             .WithApiKey("SomeApiKeyHere")
+                             .WithAccessToken("SomeApiKeyHere")
                              .BuildString();
 
-    std::string expected = "https://eu.api.battle.net/wow/item/14423?locale=en_GB&apikey=SomeApiKeyHere";
+    std::string expected = "https://eu.api.battle.net/wow/item/14423?locale=en_GB&access_token=SomeApiKeyHere";
     EXPECT_EQ(expected, actual);
 }
 
 TEST(ItemSetEndpointBuilderTest, DefaultParamsTest)
 {
     std::string actual = BlizzItemSetEndpointBuilder::GetBuilder().BuildString();
-    std::string expected = "https://eu.api.battle.net/wow/item/set/1060?locale=en_GB&apikey=abcdefghijklmnopqrstuvwxyz";
+    std::string expected = "https://eu.api.battle.net/wow/item/set/1060?locale=en_GB&access_token=abcdefghijklmnopqrstuvwxyz";
     EXPECT_EQ(expected, actual);
 }
 
@@ -56,7 +56,7 @@ TEST(ItemSetEndpointBuilderTest, EuCommItemSet)
                              .WithLocale(WOW_LOCALE::BL_FR_FR)
                              .BuildString();
 
-    std::string expected = "https://eu.api.battle.net/wow/item/set/1061?locale=fr_FR&apikey=abcdefghijklmnopqrstuvwxyz";
+    std::string expected = "https://eu.api.battle.net/wow/item/set/1061?locale=fr_FR&access_token=abcdefghijklmnopqrstuvwxyz";
     EXPECT_EQ(expected, actual);
 }
 } // namespace testing


### PR DESCRIPTION
Replaced WithApiKey() with WithAccessToken(), because the Blizzard endpoint no longer works with api key only